### PR TITLE
Fix for functions declared "local function"

### DIFF
--- a/example/example.lua
+++ b/example/example.lua
@@ -30,6 +30,10 @@ function factorial(n)
     end
 end
 
+--! @brief a simple function declared local
+local function localFunction()
+end
+
 --! a function namespace
 luaCharacter = inheritsFrom( nil, "luaCharacter" )
 

--- a/lib/Doxygen/Lua.pm
+++ b/lib/Doxygen/Lua.pm
@@ -91,6 +91,13 @@ sub parse {
             $line =~ s/:/-/;
             $result .= "$line\n";
         }
+	#local function start
+   	elsif ($line =~ /^local.+function/) {
+            $in_function = 1;
+            $line .= q{;};
+            $line =~ s/function\s+/function-/;
+            $result .= "$line\n";
+        }
         # function end
         elsif ($in_function == 1 && $line =~ /^end/) {
             $in_function = 0;


### PR DESCRIPTION
When generating docs for lua files containing local function the generated file was incorrect.

Hope this is a good fix for doxygen-lua

let me know
Stefano
