### PR TITLE
Fix member grouping

### DIFF
--- a/lib/Doxygen/Lua.pm
+++ b/lib/Doxygen/Lua.pm
@@ -72,6 +72,10 @@ sub parse {
     foreach my $line (<FH>) {
         chomp $line;
 
+        # include empty lines
+        if ($line =~ m{^\s*$}) {
+            $result .= "\n"
+        }
         # skip normal comments
         next if $line =~ /^\s*--[^!]/;
         # remove end of line comments


### PR DESCRIPTION
Hello,

I am not able to use member groups reliably. 

``` lua
--! @name system flags manipulation
--! @{

--! @public @memberof ulatency
function ulatency.add_adjust_flag(lst, match, adj)
-- ... more functions declarations here...

--! @}
```

In the above code, doxygen treats the first function docblock as a part of the opening docblock, because blank lines are discarded.

This patches Lua.pm to simple preserve empty line so member groups do work reliably.

Cheers, Petr
